### PR TITLE
Serve custom html file name without uri modifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "godot-https-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godot-https-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 [dependencies]
 hyper = { version = "0.14", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Installing `godot-https-server` as a global tool allows you to serve not just a 
 
 ```
 cargo install --path .
-cd $home/Library/Caches/Godot/web/
+cd ~/.cache/godot/editor/tmp_web_export/
 ```
 
 ### Specifying a custom html file

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ sudo ./target/release/godot-web-server
 
 ## 🎛️ Advanced Usage
 
+### Install as a global tool
+
+Installing `godot-https-server` as a global tool allows you to serve not just a Godot release build but also development builds.
+
+```
+cargo install --path .
+cd $home/Library/Caches/Godot/web/
+```
+
+### Specifying a custom html file
+
+By default, `godot-https-server` defaults to the index.html file in the current directory where the commmand was executed. You can use the `--filename` or `-f` argument to specify a custom html file name. This is useful for serving the Godot development build folder without appending the filename to the localhost address URI.
+
+```
+cd $home/Library/Caches/Godot/web/
+godot-https-server --filename tmp_js_export.html
+```
+
 ### Custom SSL Certificates
 
 Replace the auto-generated certs:

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,15 @@ async fn handle_request(req: Request<Body>) -> Result<Response<Body>, Infallible
         let slice = current.as_str();
 
         if slice == "--filename" || slice == "-f" {
-            html_file = args[index + 1].as_str();
+            let potential_next = args.get(index + 1);
+
+            match potential_next {
+                Some(next) => html_file = next, //use this filename
+                None => {
+                    println!("Missing filename argument.");
+                    break;
+                }
+            }
         }
     }
     println!("Serving HTML file: {}", html_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use hyper::{server::conn::Http, service::service_fn, Body, Request, Response, StatusCode};
-use std::{convert::Infallible, fs, net::SocketAddr, path::Path, sync::Arc};
+use std::{convert::Infallible, env, fs, net::SocketAddr, path::Path, sync::Arc};
 use tokio::{fs::File, net::TcpListener};
 use tokio_rustls::TlsAcceptor;
 use rcgen::generate_simple_self_signed;
@@ -50,10 +50,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 async fn handle_request(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    let args: Vec<String> = env::args().collect();
+    let mut html_file = "index.html";
+
+    for index in 0..args.len() {
+        let current = &args[index];
+        let slice = current.as_str();
+
+        if slice == "--filename" || slice == "-f" {
+            html_file = args[index + 1].as_str();
+        }
+    }
+    println!("Serving HTML file: {}", html_file);
+
     let path = req.uri().path();
     let query = req.uri().query().unwrap_or_default();
     let file_path = match path {
-        "/" => "index.html",
+        "/" => html_file,
         _ => path.trim_start_matches('/'),
     };
     // 读取文件内容


### PR DESCRIPTION
This allows a user to serve the development build folder without exporting a web build.

For Godot 3.5+ this folder is at: `C:/Users/<username>/AppData/Local/Godot/web`.
For Godot 4+ this folder at: `C:/Users/<username>/Library/Caches/Godot/web`.

Sample log output:

```
PS C:\Users\sjsui\AppData\Local\Godot\web> godot-https-server -f tmp_js_export.html
🚀 Server running at: https://localhost:8443
🔉 Audio mode control: https://localhost:8443?audio=worklet|legacy
TLS handshake failed: received fatal alert: CertificateUnknown
TLS handshake failed: received fatal alert: CertificateUnknown
TLS handshake failed: received fatal alert: CertificateUnknown
TLS handshake failed: received fatal alert: CertificateUnknown
Serving HTML file: tmp_js_export.html
Serving HTML file: tmp_js_export.html
Serving HTML file: tmp_js_export.html
Serving HTML file: tmp_js_export.html
Serving HTML file: tmp_js_export.html
TLS handshake failed: received fatal alert: CertificateUnknown
TLS handshake failed: received fatal alert: CertificateUnknown
```